### PR TITLE
fix(sys): fix clippy warnings via safer APIs

### DIFF
--- a/examples/sample.rs
+++ b/examples/sample.rs
@@ -3,9 +3,9 @@ use webview_rust_sys::{
 };
 
 fn main() {
-    let data = webview_create(true, None);
-    webview_set_title(data, "TEST");
-    webview_set_size(data, 800, 600, SizeHint::NONE);
-    webview_navigate(data, "https://google.com");
-    webview_run(data);
+    let mut data = webview_create(true, None);
+    webview_set_title(&mut data, "TEST");
+    webview_set_size(&mut data, 800, 600, SizeHint::NONE);
+    webview_navigate(&mut data, "https://google.com");
+    webview_run(&mut data);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,10 +2,14 @@ use std::ffi::CString;
 use std::os::raw::*;
 use std::ptr::null_mut;
 
-type DispatchFn = extern "C" fn(webview: *mut Webview, arg: *mut c_void);
-type BindFn = extern "C" fn(seq: *const c_char, req: *const c_char, arg: *mut c_void);
+pub struct Webview(*mut ffi::Webview);
 
-pub enum Webview {}
+impl Drop for Webview {
+    fn drop(&mut self) {
+        unsafe { ffi::webview_destroy(self.0) }
+    }
+}
+
 pub enum Window {}
 
 #[repr(i32)]
@@ -17,8 +21,13 @@ pub enum SizeHint {
 }
 
 mod ffi {
-    use crate::{BindFn, DispatchFn, SizeHint, Webview, Window};
+    use crate::{SizeHint, Window};
     use std::os::raw::*;
+
+    pub type DispatchFn = extern "C" fn(webview: *mut Webview, arg: *mut c_void);
+    pub type BindFn = extern "C" fn(seq: *const c_char, req: *const c_char, arg: *mut c_void);
+
+    pub enum Webview {}
 
     extern "C" {
         pub fn webview_create(debug: c_int, window: *mut Window) -> *mut Webview;
@@ -47,65 +56,67 @@ mod ffi {
     }
 }
 
-pub fn webview_create(debug: bool, window: Option<*mut Window>) -> *mut Webview {
+pub fn webview_create(debug: bool, window: Option<&mut Window>) -> Webview {
     if let Some(w) = window {
-        unsafe { ffi::webview_create(debug as c_int, w) }
+        Webview(unsafe { ffi::webview_create(debug as c_int, w as *mut Window) })
     } else {
-        unsafe { ffi::webview_create(debug as c_int, null_mut()) }
+        Webview(unsafe { ffi::webview_create(debug as c_int, null_mut()) })
     }
 }
 
-pub fn webview_dispatch(w: *mut Webview, f: DispatchFn, arg: *mut c_void) {
-    unsafe { ffi::webview_dispatch(w, f.into(), arg) }
+pub fn webview_dispatch(w: &mut Webview, f: ffi::DispatchFn, arg: &str) {
+    let c_arg = CString::new(arg).expect("No nul bytes in parameter arg");
+    unsafe { ffi::webview_dispatch(w.0, f.into(), c_arg.as_ptr() as *mut _) }
 }
 
-pub fn webview_set_title(w: *mut Webview, title: &str) {
+pub fn webview_set_title(w: &mut Webview, title: &str) {
     let c_title = CString::new(title).expect("No nul bytes in parameter title");
-    unsafe { ffi::webview_set_title(w, c_title.as_ptr()) }
+    unsafe { ffi::webview_set_title(w.0, c_title.as_ptr()) }
 }
 
-pub fn webview_navigate(w: *mut Webview, url: &str) {
+pub fn webview_navigate(w: &mut Webview, url: &str) {
     let c_url = CString::new(url).expect("No nul bytes in parameter url");
-    unsafe { ffi::webview_navigate(w, c_url.as_ptr()) }
+    unsafe { ffi::webview_navigate(w.0, c_url.as_ptr()) }
 }
 
-pub fn webview_init(w: *mut Webview, js: &str) {
+pub fn webview_init(w: &mut Webview, js: &str) {
     let c_js = CString::new(js).expect("No nul bytes in parameter js");
-    unsafe { ffi::webview_init(w, c_js.as_ptr()) }
+    unsafe { ffi::webview_init(w.0, c_js.as_ptr()) }
 }
 
-pub fn webview_eval(w: *mut Webview, js: &str) {
+pub fn webview_eval(w: &mut Webview, js: &str) {
     let c_js = CString::new(js).expect("No nul bytes in parameter js");
-    unsafe { ffi::webview_eval(w, c_js.as_ptr()) }
+    unsafe { ffi::webview_eval(w.0, c_js.as_ptr()) }
 }
 
-pub fn webview_bind(w: *mut Webview, name: &str, f: BindFn, arg: *mut c_void) {
+pub fn webview_bind(w: &mut Webview, name: &str, f: ffi::BindFn, arg: &str) {
     let c_name = CString::new(name).expect("No nul bytes in parameter name");
-    unsafe { ffi::webview_bind(w, c_name.as_ptr(), f.into(), arg) }
+    let c_arg = CString::new(arg).expect("No nul bytes in parameter arg");
+    unsafe { ffi::webview_bind(w.0, c_name.as_ptr(), f.into(), c_arg.as_ptr() as *mut _) }
 }
 
-pub fn webview_return(w: *mut Webview, seq: &str, status: c_int, result: &str) {
+pub fn webview_return(w: &mut Webview, seq: &str, status: c_int, result: &str) {
     let c_seq = CString::new(seq).expect("No nul bytes in parameter seq");
     let c_result = CString::new(result).expect("No nul bytes in parameter result");
-    unsafe { ffi::webview_return(w, c_seq.as_ptr(), status, c_result.as_ptr()) }
+    unsafe { ffi::webview_return(w.0, c_seq.as_ptr(), status, c_result.as_ptr()) }
 }
 
-pub fn webview_set_size(w: *mut Webview, width: i32, height: i32, hints: SizeHint) {
-    unsafe { ffi::webview_set_size(w, width, height, hints) }
+pub fn webview_set_size(w: &mut Webview, width: i32, height: i32, hints: SizeHint) {
+    unsafe { ffi::webview_set_size(w.0, width, height, hints) }
 }
 
-pub fn webview_run(w: *mut Webview) {
-    unsafe { ffi::webview_run(w) }
+pub fn webview_run(w: &mut Webview) {
+    unsafe { ffi::webview_run(w.0) }
 }
 
-pub fn webview_destroy(w: *mut Webview) {
-    unsafe { ffi::webview_destroy(w) }
+pub fn webview_destroy(w: Webview) {
+    unsafe { ffi::webview_destroy(w.0) }
 }
 
-pub fn webview_get_window(w: *mut Webview) -> *mut Window {
-    unsafe { ffi::webview_get_window(w) }
+pub fn webview_get_window(w: &mut Webview) -> *mut Window {
+    unsafe { ffi::webview_get_window(w.0) }
 }
 
-pub fn webview_terminate(w: *mut Webview) {
-    unsafe { ffi::webview_terminate(w) }
+pub fn webview_terminate(w: &mut Webview) {
+    unsafe { ffi::webview_terminate(w.0) }
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [x] Yes. But only parameters are changed. Provided functions are still the same.
- [ ] No


**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Refactor public functions with parameters that are more idiomatic in Rust since Clippy will warn us that dereference raw pointer is unsafe.