### PR TITLE
 Refactor signature of bind method

### DIFF
--- a/examples/sample.rs
+++ b/examples/sample.rs
@@ -1,11 +1,19 @@
-use webview_rust_sys::{
-    Webview, SizeHint,
-};
+use webview_rust_sys::{SizeHint, Webview};
 
 fn main() {
     let mut data = Webview::create(true, None);
     data.set_title("TEST");
-    data.set_size(800, 600, SizeHint::NONE);
+    data.set_size(1024, 768, SizeHint::NONE);
+    data.init("window.x = 42");
+    data.dispatch(|w| {
+        w.set_size(800, 600, SizeHint::MIN);
+        println!("Hello World");
+    });
+    let mut w = data.clone();
+    data.bind("xxx", move |seq, _req| {
+        w.eval("console.log('The anwser is ' + window.x);");
+        w.r#return(seq, 0, "{ result: 'We always knew it!' }");
+    });
     data.navigate("https://google.com");
     data.run();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
-use std::ffi::{CString, CStr};
+use std::ffi::{CStr, CString};
+use std::mem;
 use std::os::raw::*;
 use std::ptr::null_mut;
-use std::mem;
 use std::sync::Arc;
 
 mod sys;
@@ -30,85 +30,108 @@ impl Drop for Webview {
 impl Webview {
     pub fn create(debug: bool, window: Option<&mut Window>) -> Webview {
         if let Some(w) = window {
-            Webview(Arc::new(unsafe { sys::webview_create(debug as c_int, w as *mut Window as *mut _) }))
+            Webview(Arc::new(unsafe {
+                sys::webview_create(debug as c_int, w as *mut Window as *mut _)
+            }))
         } else {
-            Webview(Arc::new(unsafe { sys::webview_create(debug as c_int, null_mut()) }))
+            Webview(Arc::new(unsafe {
+                sys::webview_create(debug as c_int, null_mut())
+            }))
         }
     }
 
     pub fn dispatch<F>(&mut self, f: F)
-    where F: FnOnce(&mut Webview) + Send + 'static
+    where
+        F: FnOnce(&mut Webview) + Send + 'static,
     {
         let closure = Box::into_raw(Box::new(f));
         extern "C" fn callback<F>(webview: sys::webview_t, arg: *mut c_void)
-        where F: FnOnce(&mut Webview) + Send + 'static
+        where
+            F: FnOnce(&mut Webview) + Send + 'static,
         {
-            let mut  webview = Webview(Arc::new(webview));
+            let mut webview = Webview(Arc::new(webview));
             let closure: Box<F> = unsafe { Box::from_raw(arg as *mut F) };
             (*closure)(&mut webview);
         }
         unsafe { sys::webview_dispatch(*self.0, Some(callback::<F>), closure as *mut _) }
     }
-    
+
     pub fn set_title(&mut self, title: &str) {
         let c_title = CString::new(title).expect("No nul bytes in parameter title");
         unsafe { sys::webview_set_title(*self.0, c_title.as_ptr()) }
     }
-    
+
     pub fn navigate(&mut self, url: &str) {
         let c_url = CString::new(url).expect("No nul bytes in parameter url");
         unsafe { sys::webview_navigate(*self.0, c_url.as_ptr()) }
     }
-    
+
     pub fn init(&mut self, js: &str) {
         let c_js = CString::new(js).expect("No nul bytes in parameter js");
         unsafe { sys::webview_init(*self.0, c_js.as_ptr()) }
     }
-    
+
     pub fn eval(&mut self, js: &str) {
         let c_js = CString::new(js).expect("No nul bytes in parameter js");
         unsafe { sys::webview_eval(*self.0, c_js.as_ptr()) }
     }
 
     pub fn bind<F>(&mut self, name: &str, f: F)
-    where F: FnMut(&str, &str) + 'static
+    where
+        F: FnMut(&str, &str) + 'static,
     {
         let c_name = CString::new(name).expect("No null bytes in parameter name");
         let closure = Box::into_raw(Box::new(f));
         extern "C" fn callback<F>(seq: *const c_char, req: *const c_char, arg: *mut c_void)
-        where F: FnMut(&str, &str) + 'static
+        where
+            F: FnMut(&str, &str) + 'static,
         {
-            let seq = unsafe { CStr::from_ptr(seq).to_str().expect("No null bytes in parameter seq") };
-            let req = unsafe { CStr::from_ptr(req).to_str().expect("No null bytes in parameter req") };
+            let seq = unsafe {
+                CStr::from_ptr(seq)
+                    .to_str()
+                    .expect("No null bytes in parameter seq")
+            };
+            let req = unsafe {
+                CStr::from_ptr(req)
+                    .to_str()
+                    .expect("No null bytes in parameter req")
+            };
             let mut f: Box<F> = unsafe { Box::from_raw(arg as *mut F) };
             (*f)(seq, req);
             mem::forget(f);
         }
-        unsafe { sys::webview_bind(*self.0, c_name.as_ptr(), Some(callback::<F>), closure as *mut _) }
+        unsafe {
+            sys::webview_bind(
+                *self.0,
+                c_name.as_ptr(),
+                Some(callback::<F>),
+                closure as *mut _,
+            )
+        }
     }
-    
+
     pub fn r#return(&mut self, seq: &str, status: c_int, result: &str) {
         let c_seq = CString::new(seq).expect("No nul bytes in parameter seq");
         let c_result = CString::new(result).expect("No nul bytes in parameter result");
         unsafe { sys::webview_return(*self.0, c_seq.as_ptr(), status, c_result.as_ptr()) }
     }
-    
+
     pub fn set_size(&mut self, width: i32, height: i32, hints: SizeHint) {
         unsafe { sys::webview_set_size(*self.0, width, height, hints as i32) }
     }
-    
+
     pub fn run(&mut self) {
         unsafe { sys::webview_run(*self.0) }
     }
-    
+
     pub fn destroy(self) {
         unsafe { sys::webview_destroy(*self.0) }
     }
-    
+
     pub fn get_window(&mut self) -> *mut Window {
         unsafe { sys::webview_get_window(*self.0) as *mut Window }
     }
-    
+
     pub fn terminate(&mut self) {
         unsafe { sys::webview_terminate(*self.0) }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 use std::ffi::{CString, CStr};
 use std::os::raw::*;
 use std::ptr::null_mut;
+use std::mem;
+use std::sync::Arc;
 
 mod sys;
 
@@ -14,20 +16,23 @@ pub enum SizeHint {
     FIXED = 3,
 }
 
-pub struct Webview(sys::webview_t);
+#[derive(Clone)]
+pub struct Webview(Arc<sys::webview_t>);
 
 impl Drop for Webview {
     fn drop(&mut self) {
-        unsafe { sys::webview_destroy(self.0) }
+        if Arc::strong_count(&self.0) == 0 {
+            unsafe { sys::webview_destroy(*self.0) }
+        }
     }
 }
 
 impl Webview {
     pub fn create(debug: bool, window: Option<&mut Window>) -> Webview {
         if let Some(w) = window {
-            Webview(unsafe { sys::webview_create(debug as c_int, w as *mut Window as *mut _) })
+            Webview(Arc::new(unsafe { sys::webview_create(debug as c_int, w as *mut Window as *mut _) }))
         } else {
-            Webview(unsafe { sys::webview_create(debug as c_int, null_mut()) })
+            Webview(Arc::new(unsafe { sys::webview_create(debug as c_int, null_mut()) }))
         }
     }
 
@@ -38,72 +43,73 @@ impl Webview {
         extern "C" fn callback<F>(webview: sys::webview_t, arg: *mut c_void)
         where F: FnOnce(&mut Webview) + Send + 'static
         {
-            let mut  webview = Webview(webview);
+            let mut  webview = Webview(Arc::new(webview));
             let closure: Box<F> = unsafe { Box::from_raw(arg as *mut F) };
             (*closure)(&mut webview);
         }
-        unsafe { sys::webview_dispatch(self.0, Some(callback::<F>), closure as *mut _) }
+        unsafe { sys::webview_dispatch(*self.0, Some(callback::<F>), closure as *mut _) }
     }
     
     pub fn set_title(&mut self, title: &str) {
         let c_title = CString::new(title).expect("No nul bytes in parameter title");
-        unsafe { sys::webview_set_title(self.0, c_title.as_ptr()) }
+        unsafe { sys::webview_set_title(*self.0, c_title.as_ptr()) }
     }
     
     pub fn navigate(&mut self, url: &str) {
         let c_url = CString::new(url).expect("No nul bytes in parameter url");
-        unsafe { sys::webview_navigate(self.0, c_url.as_ptr()) }
+        unsafe { sys::webview_navigate(*self.0, c_url.as_ptr()) }
     }
     
     pub fn init(&mut self, js: &str) {
         let c_js = CString::new(js).expect("No nul bytes in parameter js");
-        unsafe { sys::webview_init(self.0, c_js.as_ptr()) }
+        unsafe { sys::webview_init(*self.0, c_js.as_ptr()) }
     }
     
     pub fn eval(&mut self, js: &str) {
         let c_js = CString::new(js).expect("No nul bytes in parameter js");
-        unsafe { sys::webview_eval(self.0, c_js.as_ptr()) }
+        unsafe { sys::webview_eval(*self.0, c_js.as_ptr()) }
     }
 
     pub fn bind<F>(&mut self, name: &str, f: F)
-    where F: FnOnce(&str, &str) + 'static
+    where F: FnMut(&str, &str) + 'static
     {
         let c_name = CString::new(name).expect("No null bytes in parameter name");
         let closure = Box::into_raw(Box::new(f));
         extern "C" fn callback<F>(seq: *const c_char, req: *const c_char, arg: *mut c_void)
-        where F: FnOnce(&str, &str) + 'static
+        where F: FnMut(&str, &str) + 'static
         {
             let seq = unsafe { CStr::from_ptr(seq).to_str().expect("No null bytes in parameter seq") };
             let req = unsafe { CStr::from_ptr(req).to_str().expect("No null bytes in parameter req") };
-            let closure: Box<F> = unsafe { Box::from_raw(arg as *mut F) };
-            (*closure)(seq, req);
+            let mut f: Box<F> = unsafe { Box::from_raw(arg as *mut F) };
+            (*f)(seq, req);
+            mem::forget(f);
         }
-        unsafe { sys::webview_bind(self.0, c_name.as_ptr(), Some(callback::<F>), closure as *mut _) }
+        unsafe { sys::webview_bind(*self.0, c_name.as_ptr(), Some(callback::<F>), closure as *mut _) }
     }
     
     pub fn r#return(&mut self, seq: &str, status: c_int, result: &str) {
         let c_seq = CString::new(seq).expect("No nul bytes in parameter seq");
         let c_result = CString::new(result).expect("No nul bytes in parameter result");
-        unsafe { sys::webview_return(self.0, c_seq.as_ptr(), status, c_result.as_ptr()) }
+        unsafe { sys::webview_return(*self.0, c_seq.as_ptr(), status, c_result.as_ptr()) }
     }
     
     pub fn set_size(&mut self, width: i32, height: i32, hints: SizeHint) {
-        unsafe { sys::webview_set_size(self.0, width, height, hints as i32) }
+        unsafe { sys::webview_set_size(*self.0, width, height, hints as i32) }
     }
     
     pub fn run(&mut self) {
-        unsafe { sys::webview_run(self.0) }
+        unsafe { sys::webview_run(*self.0) }
     }
     
     pub fn destroy(self) {
-        unsafe { sys::webview_destroy(self.0) }
+        unsafe { sys::webview_destroy(*self.0) }
     }
     
     pub fn get_window(&mut self) -> *mut Window {
-        unsafe { sys::webview_get_window(self.0) as *mut Window }
+        unsafe { sys::webview_get_window(*self.0) as *mut Window }
     }
     
     pub fn terminate(&mut self) {
-        unsafe { sys::webview_terminate(self.0) }
+        unsafe { sys::webview_terminate(*self.0) }
     }
 }

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -1,4 +1,4 @@
-use std::os::raw::{c_void, c_char, c_int};
+use std::os::raw::{c_char, c_int, c_void};
 
 pub type DispatchFn = extern "C" fn(webview: webview_t, arg: *mut c_void);
 pub type BindFn = extern "C" fn(seq: *const c_char, req: *const c_char, arg: *mut c_void);
@@ -7,10 +7,7 @@ pub type BindFn = extern "C" fn(seq: *const c_char, req: *const c_char, arg: *mu
 pub type webview_t = *mut c_void;
 
 extern "C" {
-    pub fn webview_create(
-        debug: c_int,
-        window: *mut c_void,
-    ) -> webview_t;
+    pub fn webview_create(debug: c_int, window: *mut c_void) -> webview_t;
 
     pub fn webview_destroy(w: webview_t);
 
@@ -18,24 +15,13 @@ extern "C" {
 
     pub fn webview_terminate(w: webview_t);
 
-    pub fn webview_dispatch(
-        w: webview_t,
-        fn_: Option<
-            unsafe extern "C" fn(w: webview_t, arg: *mut c_void),
-        >,
-        arg: *mut c_void,
-    );
+    pub fn webview_dispatch(w: webview_t, fn_: Option<DispatchFn>, arg: *mut c_void);
 
     pub fn webview_get_window(w: webview_t) -> *mut c_void;
 
     pub fn webview_set_title(w: webview_t, title: *const c_char);
 
-    pub fn webview_set_size(
-        w: webview_t,
-        width: c_int,
-        height: c_int,
-        hints: c_int,
-    );
+    pub fn webview_set_size(w: webview_t, width: c_int, height: c_int, hints: c_int);
 
     pub fn webview_navigate(w: webview_t, url: *const c_char);
 
@@ -43,23 +29,7 @@ extern "C" {
 
     pub fn webview_eval(w: webview_t, js: *const c_char);
 
-    pub fn webview_bind(
-        w: webview_t,
-        name: *const c_char,
-        fn_: Option<
-            unsafe extern "C" fn(
-                seq: *const c_char,
-                req: *const c_char,
-                arg: *mut c_void,
-            ),
-        >,
-        arg: *mut c_void,
-    );
+    pub fn webview_bind(w: webview_t, name: *const c_char, fn_: Option<BindFn>, arg: *mut c_void);
 
-    pub fn webview_return(
-        w: webview_t,
-        seq: *const c_char,
-        status: c_int,
-        result: *const c_char,
-    );
+    pub fn webview_return(w: webview_t, seq: *const c_char, status: c_int, result: *const c_char);
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
This commit change the trait bound on bind to FnMut to make it actually
works on practice. It has to call the mem::forget or the closure will
just be dropped.

The instance is also changed with Arc to make user able to reference
count them safely across thread (on Rust side, we "trust" original
webview knows about thread safety)

See example to get a look how these methods are called.