### PR TITLE
fully qualify path to Windows dll in build script

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,6 @@
 use cc::Build;
 use std::env;
+use std::path::PathBuf;
 
 fn main() {
     let mut build = Build::new();
@@ -29,15 +30,22 @@ fn main() {
             println!("cargo:rustc-link-lib={}", lib);
         }
 
-        let webview2_path = if target.contains("x86_64") {
-            "webview-official/script/Microsoft.Web.WebView2.0.9.488/build/native/x64/WebView2Loader.dll"
+        let webview2_arch = if target.contains("x86_64") {
+            "x64"
         } else {
-            "webview-official/script/Microsoft.Web.WebView2.0.9.488/build/native/x86/WebView2Loader.dll"
+            "x86"
         };
 
-        println!("cargo:rustc-link-lib={}", webview2_path);
+        // calculate full path to WebView2Loader.dll
+        let mut webview2_path_buf = PathBuf::from(env::current_dir().unwrap().to_str().unwrap());
+        webview2_path_buf.push("webview-official/script/Microsoft.Web.WebView2.0.9.488/build/native");
+        webview2_path_buf.push(webview2_arch);
+        let webview2_dir = webview2_path_buf.as_path().to_str().unwrap();
 
-        println!("cargo:rustc-link-search={}", webview2_path);
+        let loader_asm_name = "WebView2Loader.dll";
+
+        println!("cargo:rustc-link-search={}", webview2_dir);
+        println!("cargo:rustc-link-lib={}", loader_asm_name);
     } else if target.contains("apple") {
         build.file("webview-official/webview.cc").flag("-std=c++11");
 


### PR DESCRIPTION
This enables building from a dependent crate.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] ~~When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)~~ **N/A**

If adding a **new feature**, the PR's description includes:
- [x] ~~A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)~~ **N/A**

**Other information:**
If you add this repo as a dependency from another crate in a Windows build, `LINK.EXE` fails because it can't find `WebView2Loader.dll`.  The error message shows:

> fatal error LNK1181: cannot open input file 'webview-official\script\Microsoft.Web.WebView2.0.9.488\build\native\x64\WebView2Loader.dll.lib'

This is because that file path is being interpreted as relative to the working directory of the dependent crate, _not_ from the `webview_rust` crate.

The fix is to include the current working directory of the build script in the search path so it's fully-qualified.

There was also a minor issue where `rustc-link-lib` should only specify the name of the library, _not_ the path; this was also fixed.

The difference between the old behavior and the new is shown below:

``` diff
-cargo:rustc-link-lib=webview-official/script/Microsoft.Web.WebView2.0.9.488/build/native/x64/WebView2Loader.dll
-cargo:rustc-link-search=webview-official/script/Microsoft.Web.WebView2.0.9.488/build/native/x64/WebView2Loader.dll
+cargo:rustc-link-search=E:\webview\webview_rust\webview-official/script/Microsoft.Web.WebView2.0.9.488/build/native\x64
+cargo:rustc-link-lib=WebView2Loader.dll
```