### PR TITLE
fix: remove static lifetime on bind callbacks

### DIFF
--- a/src/webview.rs
+++ b/src/webview.rs
@@ -109,13 +109,13 @@ impl Webview {
 
     pub fn bind<F>(&mut self, name: &str, f: F)
     where
-        F: FnMut(&str, &str) + 'static,
+        F: FnMut(&str, &str),
     {
         let c_name = CString::new(name).expect("No null bytes in parameter name");
         let closure = Box::into_raw(Box::new(f));
         extern "C" fn callback<F>(seq: *const c_char, req: *const c_char, arg: *mut c_void)
         where
-            F: FnMut(&str, &str) + 'static,
+            F: FnMut(&str, &str),
         {
             let seq = unsafe {
                 CStr::from_ptr(seq)


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
remove static lifetime since many references in FnMut don't have this. 