### PR TITLE
fix: package within the publish step

### DIFF
--- a/.changes/config.json
+++ b/.changes/config.json
@@ -33,14 +33,13 @@
           "command": "echo \"\\`\\`\\`\"",
           "dryRunCommand": true,
           "pipe": true
-        },
-        {
-          "command": "cargo package --allow-dirty",
-          "dryRunCommand": true,
-          "pipe": true
         }
       ],
       "publish": [
+        {
+          "command": "cargo package --allow-dirty",
+          "dryRunCommand": true
+        },
         {
           "command": "echo \"# Cargo Publish\"",
           "dryRunCommand": true,


### PR DESCRIPTION
It is verifying the version which breaks as the version dep isn't yet published. Move this to the publish step which will mean that sys will already be published by the time we attempt to package.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [ ] No


**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
