### PR TITLE
Implement Send/Sync trait to Webview

### DIFF
--- a/.changes/send-trait.md
+++ b/.changes/send-trait.md
@@ -1,0 +1,5 @@
+---
+"webview": minor
+---
+
+Implement Send/Sync trait to Webview

--- a/examples/sample.rs
+++ b/examples/sample.rs
@@ -15,9 +15,9 @@ fn main() {
         .url("https://google.com")
         .build();
 
-    let mut w = webview.clone();
+    webview.eval("console.log('The anwser is ' + window.x);");
+    let w = webview.as_mut();
     webview.bind("xxx", move |seq, _req| {
-        w.eval("console.log('The anwser is ' + window.x);");
         w.r#return(seq, 0, "{ result: 'We always knew it!' }");
     });
     webview.run();

--- a/src/webview.rs
+++ b/src/webview.rs
@@ -25,11 +25,13 @@ impl Default for SizeHint {
     }
 }
 
-#[derive(Clone)]
 pub struct Webview<'a> {
     inner: Arc<sys::webview_t>,
     url: &'a str,
 }
+
+unsafe impl Send for Webview<'_> {}
+unsafe impl Sync for Webview<'_> {}
 
 impl<'a> Drop for Webview<'a> {
     fn drop(&mut self) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

@lucasfernog I would like to make the async refactoring as simple as possible.
I hope we can just use `Webview instance` in most of cases.
Does this look good to you?
Does `WebviewMut` also need `eval` method to it?

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [x] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [ ] No


**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
