### PR TITLE
update webview, use static lib on windows

### DIFF
--- a/webview-official-sys/build.rs
+++ b/webview-official-sys/build.rs
@@ -1,33 +1,18 @@
 use cc::Build;
 use std::env;
-use std::fs;
 use std::path::PathBuf;
 
 fn main() {
     let mut build = Build::new();
-
     let target = env::var("TARGET").unwrap();
 
-    build
-        .cpp(true)
-        .include("webview-official/webview.h")
-        .flag_if_supported("/std:c++11")
-        .flag_if_supported("-w");
-
-    // if env::var("DEBUG").is_err() {
-    //     build.define("NDEBUG", None);
-    // } else {
-    //     build.define("DEBUG", None);
-    // }
-
     if target.contains("windows") {
-        // build.define("UNICODE", None); // doesn't work atm.
         build
             .file("webview-official/webview.cc")
             .flag_if_supported("/std:c++17");
         build.include("webview-official/script");
 
-        for &lib in &["windowsapp", "user32", "oleaut32", "ole32"] {
+        for &lib in &["windowsapp", "user32", "oleaut32", "ole32", "version", "shell32"] {
             println!("cargo:rustc-link-lib={}", lib);
         }
 
@@ -37,40 +22,24 @@ fn main() {
             "x86"
         };
 
-        // calculate full path to WebView2Loader.dll
+        // calculate full path to WebView2LoaderStatic.lib
         let mut webview2_path_buf = PathBuf::from(env::current_dir().unwrap().to_str().unwrap());
         webview2_path_buf
-            .push("webview-official/script/Microsoft.Web.WebView2.0.9.488/build/native");
+            .push("webview-official/script/microsoft.web.webview2.1.0.664.37/build/native");
         webview2_path_buf.push(webview2_arch);
         let webview2_dir = webview2_path_buf.as_path().to_str().unwrap();
 
-        let loader_asm_name = "WebView2Loader.dll";
+        let loader_asm_name = "WebView2LoaderStatic";
 
         println!("cargo:rustc-link-search={}", webview2_dir);
         println!("cargo:rustc-link-lib={}", loader_asm_name);
-
-        // copy WebView2Loader.dll to `target/debug`
-        let mut src_asm_buf = PathBuf::from(webview2_dir);
-        src_asm_buf.push(loader_asm_name);
-
-        // we want to be able to calculate C:\crate\root\target\debug\
-        //           while we can get this ^^^^^^^^^^^^^   and  ^^^^^ from env::current_dir() and %PROFILE% respectively
-        // there's no way to get this (reliably)         ^^^^^^
-        // we can, however, use %OUT_DIR% (C:\crate\root\target\debug\build\webview_rust-xxxx\out\)
-        // and navigate backwards to here  ^^^^^^^^^^^^^^^^^^^^^^^^^^
-        let mut target_asm_buf = PathBuf::from(env::var("OUT_DIR").unwrap());
-        target_asm_buf.pop();
-        target_asm_buf.pop();
-        target_asm_buf.pop();
-        target_asm_buf.push(loader_asm_name);
-
-        fs::copy(src_asm_buf.as_path(), target_asm_buf.as_path()).unwrap();
     } else if target.contains("apple") {
         build.file("webview-official/webview.cc").flag("-std=c++11");
 
         println!("cargo:rustc-link-lib=framework=Cocoa");
         println!("cargo:rustc-link-lib=framework=WebKit");
     } else if target.contains("linux") || target.contains("bsd") {
+        build.file("webview-official/webview.cc");
         let lib = pkg_config::Config::new()
             .atleast_version("2.8")
             .probe("webkit2gtk-4.0")
@@ -79,12 +48,6 @@ fn main() {
         for path in lib.include_paths {
             build.include(path);
         }
-        // pkg_config::Config::new()
-        //     .atleast_version("3.0")
-        //     .probe("gtk+-3.0")
-        //     .unwrap();
-
-        build.file("webview-official/webview.cc");
     } else {
         panic!("Unsupported platform");
     }

--- a/webview-official-sys/build.rs
+++ b/webview-official-sys/build.rs
@@ -8,7 +8,8 @@ fn main() {
     build
       .cpp(true)
       .include("webview-official/webview.h")
-      .flag_if_supported("/std:c++11");
+      .flag_if_supported("/std:c++11")
+      .flag_if_supported("-w");
 
     if target.contains("windows") {
         build

--- a/webview-official-sys/build.rs
+++ b/webview-official-sys/build.rs
@@ -3,8 +3,12 @@ use std::env;
 use std::path::PathBuf;
 
 fn main() {
-    let mut build = Build::new();
     let target = env::var("TARGET").unwrap();
+    let mut build = Build::new();
+    build
+      .cpp(true)
+      .include("webview-official/webview.h")
+      .flag_if_supported("/std:c++11");
 
     if target.contains("windows") {
         build


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
This updates webview and also uses the static build of WebView2Loader instead of the dll on Windows. This means no need to copy the dll into the target dir, nor is it needed with deployment of webview apps.

- [ ] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ x] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
No the change doesn't affect the api of the library. It might affect workflows requiring the dll for deployment.


**The PR fulfills these requirements:**

- [x ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
